### PR TITLE
feat: Ignore coffea vector warnings

### DIFF
--- a/src/atlas_schema/__init__.py
+++ b/src/atlas_schema/__init__.py
@@ -6,7 +6,11 @@ atlas_schema: Collection of utilities and helper functions for HEP ATLAS analyse
 
 from __future__ import annotations
 
+import warnings
+
 from atlas_schema._version import version as __version__
 from atlas_schema.enums import ParticleOrigin, PhotonID
+
+warnings.filterwarnings("ignore", module="coffea.*")
 
 __all__ = ["ParticleOrigin", "PhotonID", "__version__"]


### PR DESCRIPTION
Some spurious warnings are raised for now that can be ignored by the end-user. See #28 for example.
