### PR TITLE
feat: Multiple Access for Enum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,7 @@ jobs:
           uv pip install --system '.[test]'
 
       - name: Test package
-        run: >-
-          python -m pytest -ra --cov --cov-report=xml --cov-report=term
-          --durations=20
+        run: python -m pytest
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v5.3.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ repos:
       - id: check-case-conflict
       - id: check-merge-conflict
       - id: check-symlinks
+      - id: check-toml
       - id: check-yaml
       - id: debug-statements
       - id: end-of-file-fixer

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -15,6 +15,14 @@ Top-Level
 Enums
 -----
 
+All enums listed below will typically allow you to access multiple values at once:
+
+   >>> import atlas_schema as ats
+   >>> ats.enums.ParticleOrigin['NonDefined']
+   <ParticleOrigin.NonDefined: 0>
+   >>> ats.enums.ParticleOrigin['NonDefined', 'Higgs']
+   [<ParticleOrigin.NonDefined: 0>, <ParticleOrigin.Higgs: 14>]
+
 .. currentmodule:: atlas_schema.enums
 
 .. autosummary::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,12 +100,12 @@ addopts = [
   "--strict-markers",
   "--strict-config",
   "--doctest-modules",
-  "--doctest-glob='*.rst'",
-  "--doctest-glob='*.md'",
+  "--doctest-glob=*.rst",
   "--cov",
   "--cov-report=xml",
   "--cov-report=term",
   "--durations=20",
+  "--ignore=docs/conf.py",
 ]
 xfail_strict = true
 filterwarnings = [
@@ -114,6 +114,7 @@ filterwarnings = [
 log_cli_level = "INFO"
 testpaths = [
   "tests",
+  "docs",
 ]
 
 [tool.coverage]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,19 @@ packages = ["src/atlas_schema"]
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config", "--doctest-modules", "--doctest-glob='*.rst'", "--doctest-glob='*.md'"]
+addopts = [
+  "-ra",
+  "--showlocals",
+  "--strict-markers",
+  "--strict-config",
+  "--doctest-modules",
+  "--doctest-glob='*.rst'",
+  "--doctest-glob='*.md'",
+  "--cov",
+  "--cov-report=xml",
+  "--cov-report=term",
+  "--durations=20",
+]
 xfail_strict = true
 filterwarnings = [
   "error",
@@ -103,7 +115,6 @@ log_cli_level = "INFO"
 testpaths = [
   "tests",
 ]
-
 
 [tool.coverage]
 run.source = ["atlas_schema"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ packages = ["src/atlas_schema"]
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
+addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config", "--doctest-modules"]
 xfail_strict = true
 filterwarnings = [
   "error",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ packages = ["src/atlas_schema"]
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config", "--doctest-modules"]
+addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config", "--doctest-modules", "--doctest-glob='*.rst'", "--doctest-glob='*.md'"]
 xfail_strict = true
 filterwarnings = [
   "error",

--- a/src/atlas_schema/enums.py
+++ b/src/atlas_schema/enums.py
@@ -1,9 +1,31 @@
 from __future__ import annotations
 
-from enum import IntEnum
+import sys
+from enum import Enum, IntEnum
+
+if sys.version_info >= (3, 11):
+    from enum import EnumType
+else:
+    from enum import EnumMeta as EnumType
+
+from typing import Callable, TypeVar, cast
+
+_E = TypeVar("_E", bound=Enum)
 
 
-class ParticleType(IntEnum):
+class MultipleEnumAccessMeta(EnumType):
+    """
+    Enum Metaclass to provide a way to access multiple values all at once.
+    """
+
+    def __getitem__(self: type[_E], key: str | tuple[str]) -> _E | list[_E]:  # type:ignore[misc,override]
+        getitem = cast(Callable[[str], _E], super().__getitem__)  # type:ignore[misc]
+        if isinstance(key, tuple):
+            return [getitem(name) for name in key]
+        return getitem(key)
+
+
+class ParticleType(IntEnum, metaclass=MultipleEnumAccessMeta):
     """
     Taken from `ATLAS Truth Utilities for ParticleType <https://gitlab.cern.ch/atlas/athena/-/blob/74f43ff0910edb2a2bd3778880ccbdad648dc037/Generators/TruthUtils/TruthUtils/TruthClasses.h#L8-49>`_.
     """
@@ -50,7 +72,7 @@ class ParticleType(IntEnum):
     UnknownJet = 38
 
 
-class ParticleOrigin(IntEnum):
+class ParticleOrigin(IntEnum, metaclass=MultipleEnumAccessMeta):
     """
     Taken from `ATLAS Truth Utilities for ParticleOrigin <https://gitlab.cern.ch/atlas/athena/-/blob/74f43ff0910edb2a2bd3778880ccbdad648dc037/Generators/TruthUtils/TruthUtils/TruthClasses.h#L51-103>`_.
     """
@@ -105,7 +127,7 @@ class ParticleOrigin(IntEnum):
     QCD = 45
 
 
-class PhotonID(IntEnum):
+class PhotonID(IntEnum, metaclass=MultipleEnumAccessMeta):
     """
     Taken from the `EGamma Identification CP group's twiki <https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/EGammaIdentificationRun2#Photon_isEM_word>`_.
     """

--- a/src/atlas_schema/utils.py
+++ b/src/atlas_schema/utils.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+from enum import Enum
 from typing import TypeVar, Union, cast
 
 import awkward as ak
 import dask_awkward as dak
 
 Array = TypeVar("Array", bound=Union[dak.Array, ak.Array])
+_E = TypeVar("_E", bound=Enum)
 
 
 def isin(haystack: Array, needles: dak.Array | ak.Array, axis: int = -1) -> Array:

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from enum import IntEnum
+
+import atlas_schema as ats
+
+
+def test_enum_multiple_access():
+    class Names(IntEnum, metaclass=ats.enums.MultipleEnumAccessMeta):
+        Alice = 0
+        Bob = 1
+        Charlie = 2
+
+    assert Names["Alice"] == Names.Alice
+    assert Names["Bob"] == Names.Bob
+    assert Names["Charlie"] == Names.Charlie
+    assert Names["Alice", "Bob"] == [Names.Alice, Names.Bob]  # type:ignore[misc,comparison-overlap]
+    assert Names["Bob", "Alice"] == [Names.Bob, Names.Alice]  # type:ignore[misc,comparison-overlap]
+    assert Names["Charlie", "Alice", "Bob"] == [Names.Charlie, Names.Alice, Names.Bob]  # type:ignore[misc,comparison-overlap]


### PR DESCRIPTION
Allows one to access multiple enum values at the same time by name:

```python
ats.enums.ParticleOrigin['NonDefined']
ats.enums.ParticleOrigin['NonDefined', 'BremPhoton']
```

which should make things easier for users who need to select multiple at the same time.

Additionally, fix up doctesting, pyproject formatting, and pre-commit with this too.
