### PR TITLE
fix: Handle singletons better and provide warnings to users

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,7 +75,7 @@ repos:
       - id: disallow-caps
         name: Disallow improper capitalization
         language: pygrep
-        entry: PyBind|Numpy|Cmake|CCache|Github|PyTest
+        entry: PyBind|Numpy(?![A-Z])|Cmake|CCache|Github|PyTest
         exclude: .pre-commit-config.yaml
 
   - repo: https://github.com/henryiii/validate-pyproject-schema-store

--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ samples, report = dataset_tools.preprocess(fileset)
 
 def noop(events):
     return ak.fields(events)
-    return events
 
 
 fields = dataset_tools.apply_to_fileset(noop, samples, schemaclass=NtupleSchema)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,55 @@ analyzers to work with ATLAS datasets (Monte Carlo and Data), using
 
 ## Hello World
 
+The simplest example is to just get started processing the file as expected:
+
+```python
+from atlas_schema.schema import NtupleSchema
+from coffea import dataset_tools
+import awkward as ak
+
+fileset = {"ttbar": {"files": {"path/to/ttbar.root": "tree_name"}}}
+samples, report = dataset_tools.preprocess(fileset)
+
+
+def noop(events):
+    return ak.fields(events)
+    return events
+
+
+fields = dataset_tools.apply_to_fileset(noop, samples, schemaclass=NtupleSchema)
+print(fields)
+```
+
+which produces something similar to
+
+```python
+{
+    "ttbar": [
+        "dataTakingYear",
+        "mcChannelNumber",
+        "runNumber",
+        "eventNumber",
+        "lumiBlock",
+        "actualInteractionsPerCrossing",
+        "averageInteractionsPerCrossing",
+        "truthjet",
+        "PileupWeight",
+        "RandomRunNumber",
+        "met",
+        "recojet",
+        "truth",
+        "generatorWeight",
+        "beamSpotWeight",
+        "trigPassed",
+        "jvt",
+    ]
+}
+```
+
+However, a more involved example to apply a selection and fill a histogram looks
+like below:
+
 ```python
 import awkward as ak
 import dask

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -1,7 +1,7 @@
 .. _faq:
 
-atlas-schema FAQ
-==========
+FAQ
+===
 
 This is a list of Frequently Asked Questions about ``atlas-schema``.  Feel free to
 suggest new entries!

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -10,6 +10,12 @@ How do I...
 -----------
 
 ... define my singletons?
+   Did you get a warning like the following when running your code?
+
+   .. code-block:: bash
+
+      RuntimeWarning: I identified a branch that likely does not have any leaves: RandomRunNumber. I will treat this as a 'singleton'. To suppress this warning next time, please define your singletons explicitly.
+
    You can define your singletons by inheriting from :class:`atlas_schema.schema.NtupleSchema`:
 
    .. code-block:: python

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -1,0 +1,23 @@
+.. _faq:
+
+atlas-schema FAQ
+==========
+
+This is a list of Frequently Asked Questions about ``atlas-schema``.  Feel free to
+suggest new entries!
+
+How do I...
+-----------
+
+... define my singletons?
+   You can define your singletons by inheriting from :class:`atlas_schema.schema.NtupleSchema`:
+
+   .. code-block:: python
+
+      from atlas_schema.schema import NtupleSchema
+
+
+      class MySchema(NtupleSchema):
+          singletons = {"RandomRunNumber", ...}
+
+   and then simply use ``MySchema`` in place of ``NtupleSchema``.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -15,7 +15,7 @@ How do I...
    .. code-block:: bash
 
       RuntimeWarning: I identified a branch that likely does not have any
-      leaves: RandomRunNumber. I will treat this as a 'singleton'. To suppress
+      leaves: 'RandomRunNumber'. I will treat this as a 'singleton'. To suppress
       this warning next time, please define your singletons explicitly.
 
    You can define your singletons by inheriting from :class:`atlas_schema.schema.NtupleSchema`:

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -14,7 +14,9 @@ How do I...
 
    .. code-block:: bash
 
-      RuntimeWarning: I identified a branch that likely does not have any leaves: RandomRunNumber. I will treat this as a 'singleton'. To suppress this warning next time, please define your singletons explicitly.
+      RuntimeWarning: I identified a branch that likely does not have any
+      leaves: RandomRunNumber. I will treat this as a 'singleton'. To suppress
+      this warning next time, please define your singletons explicitly.
 
    You can define your singletons by inheriting from :class:`atlas_schema.schema.NtupleSchema`:
 

--- a/docs/history.md
+++ b/docs/history.md
@@ -25,7 +25,7 @@ and this project adheres to
 - Singleton branches were not handled properly in some ntuples used by `ATLAS`
   analyzers. Now, the schema will raise a {class}`RuntimeWarning` if the user
   does not explicitly define the singletons they have in their input files. See
-  additionally the [faq]() for some details as well. ({issue}`19`, {pr}`48`)
+  additionally the {ref}`faq` for some details as well. ({issue}`19`, {pr}`48`)
 
 (atlas-schema-v0.2.2)=
 

--- a/docs/history.md
+++ b/docs/history.md
@@ -14,6 +14,19 @@ and this project adheres to
 
 **_Fixed:_**
 
+(atlas-schema-v0.2.3)=
+
+## [0.2.3](https://github.com/scipp-atlas/atlas-schema/releases/tag/v0.2.3) - 2025-02-15
+
+**_Changed:_**
+
+**_Fixed:_**
+
+- Singleton branches were not handled properly in some ntuples used by `ATLAS`
+  analyzers. Now, the schema will raise a {class}`RuntimeWarning` if the user
+  does not explicitly define the singletons they have in their input files. See
+  additionally the [faq]() for some details as well. ({issue}`19`, {pr}`48`)
+
 (atlas-schema-v0.2.2)=
 
 ## [0.2.2](https://github.com/scipp-atlas/atlas-schema/releases/tag/v0.2.2) - 2025-02-13

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,7 @@
 :hidden:
 api
 history
+faq
 ```
 
 ```{include} ../README.md

--- a/src/atlas_schema/schema.py
+++ b/src/atlas_schema/schema.py
@@ -186,7 +186,7 @@ class NtupleSchema(BaseSchema):  # type: ignore[misc]
                 contents = output[name]["contents"]
             elif output[name]["class"] == "NumpyArray":
                 # these are singletons that we just pass through
-                pass
+                continue
             else:
                 msg = f"Unhandled class {output[name]['class']}"
                 raise RuntimeError(msg)

--- a/src/atlas_schema/schema.py
+++ b/src/atlas_schema/schema.py
@@ -165,7 +165,7 @@ class NtupleSchema(BaseSchema):  # type: ignore[misc]
 
             if not used and not content:
                 warnings.warn(
-                    f"I identified a branch that likely does not have any leaves: {name}. I will treat this as a 'singleton'. To suppress this warning next time, please define your singletons explicitly.",
+                    f"I identified a branch that likely does not have any leaves: '{name}'. I will treat this as a 'singleton'. To suppress this warning next time, please define your singletons explicitly.",
                     RuntimeWarning,
                     stacklevel=2,
                 )

--- a/src/atlas_schema/schema.py
+++ b/src/atlas_schema/schema.py
@@ -165,8 +165,7 @@ class NtupleSchema(BaseSchema):  # type: ignore[misc]
 
             if not used and not content:
                 warnings.warn(
-                    f"I identified a branch that likely does not have any leaves: {name}.\n\
-                    I will treat this as a 'singleton'. To suppress this warning next time, please define your singletons explicitly.",
+                    f"I identified a branch that likely does not have any leaves: {name}. I will treat this as a 'singleton'. To suppress this warning next time, please define your singletons explicitly.",
                     RuntimeWarning,
                     stacklevel=2,
                 )


### PR DESCRIPTION
Resolves #19.

The issue there is that the team is using a mix of singletons and singleton-like branches (collections without any subcollections to group/zip-forms for) so `schema.py` is updated to be smarter about this and warning the user to be explicitly defining this.
