### PR TITLE
fix: events.__getitem__ fails for arrays with string comparison

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -14,6 +14,23 @@ and this project adheres to
 
 **_Fixed:_**
 
+(atlas-schema-v0.4.1)=
+
+## [0.4.1](https://github.com/scipp-atlas/atlas-schema/releases/tag/v0.4.1) - 2025-10-07
+
+**_Fixed:_**
+
+- bug-fix from introduction of systematic variation support in event-level
+  masking {pr}`75`
+
+(atlas-schema-v0.4.0)=
+
+## [0.4.0](https://github.com/scipp-atlas/atlas-schema/releases/tag/v0.4.0) - 2025-09-11
+
+**_Added:_**
+
+- systematic variation support! {pr}`66`
+
 (atlas-schema-v0.3.0)=
 
 ## [0.3.0](https://github.com/scipp-atlas/atlas-schema/releases/tag/v0.3.0) - 2025-07-29

--- a/src/atlas_schema/methods.py
+++ b/src/atlas_schema/methods.py
@@ -41,7 +41,7 @@ class NtupleEvents(behavior["NanoEvents"]):  # type: ignore[misc, valid-type, na
         Returns:
             The requested systematic variation or nominal events for "NOSYS".
         """
-        if key == "NOSYS":
+        if isinstance(key, str) and key == "NOSYS":
             return self
         return super().__getitem__(key)
 

--- a/src/atlas_schema/methods.py
+++ b/src/atlas_schema/methods.py
@@ -89,7 +89,7 @@ class NtupleEventsArray(behavior[("*", "NanoEvents")]):  # type: ignore[misc, va
         Returns:
             The requested systematic variation or nominal events for "NOSYS".
         """
-        if key == "NOSYS":
+        if isinstance(key, str) and key == "NOSYS":
             return self
         return super().__getitem__(key)
 


### PR DESCRIPTION
Reported by @robles-bot from running https://github.com/usatlas/AF-Benchmarking/blob/main/NTuple_Hist/coffea/UC/run_example.sh .

Before this fix, a traceback like the following occurred

```
Applying to fileset
Traceback (most recent call last):
  File "/srv/example.py", line 110, in <module>
    main()
  File "/srv/example.py", line 86, in main
    out = apply_to_fileset(
  File "/alrb/.local/lib/python3.9/site-packages/coffea/dataset_tools/apply_processor.py", line 129, in apply_to_fileset
    dataset_out = apply_to_dataset(
  File "/alrb/.local/lib/python3.9/site-packages/coffea/dataset_tools/apply_processor.py", line 84, in apply_to_dataset
    out = data_manipulation.process(events)
  File "/srv/example.py", line 44, in process
    phcut=events[cut].ph.passes("tightID")
  File "/alrb/.local/lib/python3.9/site-packages/dask_awkward/lib/core.py", line 1606, in __getitem__
    return self._getitem_single(where)
  File "/alrb/.local/lib/python3.9/site-packages/dask_awkward/lib/core.py", line 1568, in _getitem_single
    return self._getitem_outer_bool_or_int_lazy_array(where)
  File "/alrb/.local/lib/python3.9/site-packages/dask_awkward/lib/core.py", line 1335, in _getitem_outer_bool_or_int_lazy_array
    new_meta = self._meta[where._meta]
  File "/alrb/.local/lib/python3.9/site-packages/atlas_schema/methods.py", line 92, in __getitem__
    if key == "NOSYS":
  File "/alrb/.local/lib/python3.9/site-packages/awkward/_operators.py", line 54, in func
    return ufunc(self, other)
  File "/alrb/.local/lib/python3.9/site-packages/awkward/highlevel.py", line 1630, in __array_ufunc__
    return ak._connect.numpy.array_ufunc(ufunc, method, inputs, kwargs)
  File "/alrb/.local/lib/python3.9/site-packages/awkward/_errors.py", line 80, in __exit__
    raise self.decorate_exception(exception_type, exception_value)
  File "/alrb/.local/lib/python3.9/site-packages/awkward/highlevel.py", line 1630, in __array_ufunc__
    return ak._connect.numpy.array_ufunc(ufunc, method, inputs, kwargs)
  File "/alrb/.local/lib/python3.9/site-packages/awkward/_connect/numpy.py", line 469, in array_ufunc
    out = ak._broadcasting.broadcast_and_apply(
  File "/alrb/.local/lib/python3.9/site-packages/awkward/_broadcasting.py", line 1219, in broadcast_and_apply
    out = apply_step(
  File "/alrb/.local/lib/python3.9/site-packages/awkward/_broadcasting.py", line 1197, in apply_step
    return continuation()
  File "/alrb/.local/lib/python3.9/site-packages/awkward/_broadcasting.py", line 1166, in continuation
    return broadcast_any_list()
  File "/alrb/.local/lib/python3.9/site-packages/awkward/_broadcasting.py", line 670, in broadcast_any_list
    outcontent = apply_step(
  File "/alrb/.local/lib/python3.9/site-packages/awkward/_broadcasting.py", line 1179, in apply_step
    result = action(
  File "/alrb/.local/lib/python3.9/site-packages/awkward/_connect/numpy.py", line 435, in action
    result = backend.nplike.apply_ufunc(ufunc, method, input_args, kwargs)
  File "/alrb/.local/lib/python3.9/site-packages/awkward/_nplikes/typetracer.py", line 639, in apply_ufunc
    return self._apply_ufunc_nep_50(ufunc, method, args, kwargs)
  File "/alrb/.local/lib/python3.9/site-packages/awkward/_nplikes/typetracer.py", line 667, in _apply_ufunc_nep_50
    input_arg_dtypes = [self._get_nep_50_dtype(obj) for obj in args]
  File "/alrb/.local/lib/python3.9/site-packages/awkward/_nplikes/typetracer.py", line 667, in <listcomp>
    input_arg_dtypes = [self._get_nep_50_dtype(obj) for obj in args]
  File "/alrb/.local/lib/python3.9/site-packages/awkward/_nplikes/typetracer.py", line 651, in _get_nep_50_dtype
    assert isinstance(obj, (int, complex, float))
AssertionError
```

which was coming from the fact that the `key == "NOSYS"` was triggering the crash. Adding a protection here and this fixes it with an additional regression test added.
