### PR TITLE
fix: bump hynek/build-and-inspect-python-package to v3.0.1

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: hynek/build-and-inspect-python-package@v2
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
 
   publish:
     needs: [dist]


### PR DESCRIPTION
Versions of build-and-inspect-python-package earlier than v3 are
broken; see https://github.com/pypa/hatch/issues/2292. Pin to the
v3.0.1 release commit SHA.

Assisted-by: Claude (Anthropic)

Committed via https://github.com/asottile/all-repos