### PR TITLE
ci: harden GitHub Actions security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,13 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
-      actions:
+      github-actions:
         patterns:
           - "*"
     labels:
       - "github-actions"
       - "dependencies"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,15 +19,20 @@ env:
   # one distinguishes color depth, where "3" -> "256-bit color".
   FORCE_COLOR: 3
 
+permissions: {}
+
 jobs:
   dist:
     name: Distribution build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout the repository
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
 
@@ -36,7 +41,7 @@ jobs:
     name: Publish to PyPI
     environment: pypi
     permissions:
-      id-token: write
+      id-token: write # trusted publishing to PyPI
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -41,10 +41,10 @@ jobs:
     if: github.event_name == 'release' && github.event.action == 'published'
 
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: Packages
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         if: github.event_name == 'release' && github.event.action == 'published'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,14 +16,19 @@ env:
   # one distinguishes color depth, where "3" -> "256-bit color".
   FORCE_COLOR: 3
 
+permissions: {}
+
 jobs:
   pre-commit:
     name: Format
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout the repository
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.x"
@@ -40,6 +45,8 @@ jobs:
     name: Check Python ${{ matrix.python-version }} on ${{ matrix.runs-on }}
     runs-on: ${{ matrix.runs-on }}
     needs: [pre-commit]
+    permissions:
+      contents: read # checkout the repository
     strategy:
       fail-fast: false
       matrix:
@@ -54,6 +61,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,13 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.x"
-      - uses: pre-commit/action@v3.0.1
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         with:
           extra_args: --hook-stage manual --all-files
       - name: Run PyLint
@@ -51,11 +51,11 @@ jobs:
             python-version: "3.13"
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
@@ -70,7 +70,7 @@ jobs:
         run: python -m pytest
 
       - name: Upload coverage report
-        uses: codecov/codecov-action@v7.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: scipp-atlas/atlas-schema

--- a/.github/workflows/semantic-pr-check.yml
+++ b/.github/workflows/semantic-pr-check.yml
@@ -1,7 +1,7 @@
 name: Semantic Pull Request
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited
@@ -11,10 +11,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   main:
     name: Validate PR title
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read # read PR title/metadata for conventional-commit validation
 
     steps:
       - name: Check PR title matches Conventional Commits spec

--- a/.github/workflows/semantic-pr-check.yml
+++ b/.github/workflows/semantic-pr-check.yml
@@ -18,6 +18,6 @@ jobs:
 
     steps:
       - name: Check PR title matches Conventional Commits spec
-        uses: amannn/action-semantic-pull-request@v6
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,13 +5,13 @@ ci:
 
 repos:
   - repo: https://github.com/adamchainz/blacken-docs
-    rev: "1.20.0"
+    rev: "fda77690955e9b63c6687d8806bafd56a526e45f" # frozen: 1.20.0
     hooks:
       - id: blacken-docs
         additional_dependencies: [black==24.*]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: "v6.0.0"
+    rev: "3e8a8703264a2f4a69428a0aa4dcb512790b2c8c" # frozen: v6.0.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -28,28 +28,30 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: "v1.10.0"
+    rev: "3a6eb0fadf60b3cccfd80bad9dbb6fae7e47b316" # frozen: v1.10.0
     hooks:
       - id: rst-backticks
       - id: rst-directive-colons
       - id: rst-inline-touching-normal
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v4.0.0-alpha.8"
+    rev: "f12edd9c7be1c20cfa42420fd0e6df71e42b51ea" # frozen: v4.0.0-alpha.8
     hooks:
       - id: prettier
         types_or: [yaml, markdown, html, css, scss, javascript, json]
         args: [--prose-wrap=always]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.15.15"
+    # held back from v0.16.1: new rules (PYI018/BLE001/RUF036) flag unrelated
+    # source/test code; needs its own change set
+    rev: "0671d8ab202c4ac093b78433ae5baf74f3fc7246" # frozen: v0.15.15
     hooks:
       - id: ruff-check
         args: ["--fix", "--show-fixes"]
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v2.1.0"
+    rev: "41e691678310dfd3833f7ab4e180ddb014310356" # frozen: v2.3.0
     hooks:
       - id: mypy
         files: src|tests
@@ -60,13 +62,13 @@ repos:
           - numpy < 2.5.0 # until we are >= 3.12 python
 
   - repo: https://github.com/codespell-project/codespell
-    rev: "v2.4.2"
+    rev: "57b21406f092110c18776e39b0bda50d37c945c8" # frozen: v2.4.3
     hooks:
       - id: codespell
         args: ["-w"]
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: "v0.11.0.1"
+    rev: "745eface02aef23e168a8afb6b5737818efbea95" # frozen: v0.11.0.1
     hooks:
       - id: shellcheck
 
@@ -79,13 +81,20 @@ repos:
         exclude: .pre-commit-config.yaml
 
   - repo: https://github.com/henryiii/validate-pyproject-schema-store
-    rev: "2026.05.28"
+    rev: "a12c4f2e45f39cfb516be7842efbe98633eb3789" # frozen: 2026.08.05
     hooks:
       - id: validate-pyproject
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: "0.37.2"
+    rev: "6b63472e72e1a91ed8a2f6d483790dfb644fa1d3" # frozen: 0.37.4
     hooks:
       - id: check-dependabot
       - id: check-github-workflows
       - id: check-readthedocs
+
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: 451b56af716f9f0d0c2b816503a3fd0cf8b036fa # frozen: v1.29.0
+    hooks:
+      - id: zizmor
+        files: "^\\.github"
+        args: [--persona=pedantic]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,9 @@ exclude = []
 [tool.hatch.build.targets.wheel]
 packages = ["src/atlas_schema"]
 
+[tool.uv]
+exclude-newer = "7 days"
+
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = [


### PR DESCRIPTION
## Summary

CI security hardening for GitHub Actions and pre-commit, following our
standard secure-ci checklist (7-day cooldown, monthly grouped updates).

- Pin every `uses:` in `.github/workflows/*.yml` to a commit SHA with a
  version comment (`actions/checkout`, `actions/setup-python`,
  `pre-commit/action`, `codecov/codecov-action`,
  `actions/download-artifact`, `pypa/gh-action-pypi-publish`,
  `amannn/action-semantic-pull-request`).
- Add `permissions: {}` at the workflow level in `ci.yml`, `cd.yml`, and
  `semantic-pr-check.yml`, with least-privilege per-job grants
  (`contents: read` for checkout, `pull-requests: read` for PR-title
  validation, and a documented `id-token: write` for PyPI trusted
  publishing).
- Set `persist-credentials: false` on checkout steps that don't need to
  push credentials.
- Switch `semantic-pr-check.yml` from `pull_request_target` to
  `pull_request`: the job never checks out PR code and doesn't need the
  elevated token `pull_request_target` grants (zizmor
  `dangerous-triggers`).
- `.github/dependabot.yml`: rename the `actions` group to
  `github-actions`, move to a monthly grouped schedule, and add a 7-day
  cooldown.
- `.pre-commit-config.yaml`: freeze all hook revs to SHAs (7-day
  cooldown) and add the `zizmor` pre-commit hook (`--persona=pedantic`)
  against `.github`.
- `pyproject.toml`: add `[tool.uv] exclude-newer = "7 days"` to match the
  cooldown used elsewhere.

## Major version changes

None of the GitHub Actions or pre-commit hooks moved a major version in
this PR:

- `actions/checkout` v7 -> v7.0.1 (patch)
- `actions/setup-python` v7 -> v7.0.0 (patch)
- `actions/download-artifact` v8 -> v8.0.1 (patch)
- `pypa/gh-action-pypi-publish` `release/v1` -> v1.14.2 (pinned, same
  major)
- `amannn/action-semantic-pull-request` v6 -> v6.1.1 (patch)
- `pre-commit/action`, `codecov/codecov-action`,
  `hynek/build-and-inspect-python-package`: unchanged version, pinned to
  SHA
- pre-commit hooks: `mypy` v2.1.0 -> v2.3.0, `codespell` v2.4.2 -> v2.4.3,
  `check-jsonschema` 0.37.2 -> 0.37.4, `validate-pyproject-schema-store`
  2026.05.28 -> 2026.08.05 -- all minor/patch, verified passing with
  `prek run -a`.

## Held back

- **`ruff-pre-commit`**: held at v0.15.15 (SHA-pinned), instead of the
  latest v0.16.1. The newer version adds `PYI018`, `BLE001`, and
  `RUF036` findings against existing, unrelated source/test code
  (`src/atlas_schema/utils.py`, `tests/test_systematics.py`,
  `src/atlas_schema/_version.pyi`, `src/atlas_schema/typing_compat.py`).
  Fixing those is out of scope for a CI-security change set; bumping
  ruff should be its own PR.

## zizmor

No ignores added. `uvx zizmor --persona=pedantic .github` is clean after
the permissions/trigger/pinning changes above.

## Verification

- `uvx zizmor --persona=pedantic .github` -> no findings.
- `uvx prek run -a` -> all hooks pass (ruff held at its current pinned
  version, confirmed no new findings there).
- `npx actions-up -y --min-age=7 --style=sha --include-branches` used to
  pin/update actions; manually verified no downgrades or non-release
  refs were picked up.

Note: `hynek/build-and-inspect-python-package` was already pinned to
`2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1` on `main` (merged in
#100) before this branch was created, so this PR doesn't touch it
further.
